### PR TITLE
Upgrade amazon-ecs-deploy-task-definition to Node 20

### DIFF
--- a/.github/workflows/update-background-service.yml
+++ b/.github/workflows/update-background-service.yml
@@ -53,7 +53,7 @@ jobs:
           > new-task-definition.json
 
       - name: Deploy task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: fullfatthings/amazon-ecs-deploy-task-definition@upgrade-to-node-20
         with:
           task-definition: new-task-definition.json
           service: ${{ inputs.service }}

--- a/.github/workflows/update-background-service.yml
+++ b/.github/workflows/update-background-service.yml
@@ -53,7 +53,7 @@ jobs:
           > new-task-definition.json
 
       - name: Deploy task definition
-        uses: fullfatthings/amazon-ecs-deploy-task-definition@upgrade-to-node-20
+        uses: fullfatthings/amazon-ecs-deploy-task-definition@master
         with:
           task-definition: new-task-definition.json
           service: ${{ inputs.service }}

--- a/.github/workflows/update-task-definition.yml
+++ b/.github/workflows/update-task-definition.yml
@@ -50,7 +50,7 @@ jobs:
           > new-task-definition.json
 
       - name: Deploy task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: fullfatthings/amazon-ecs-deploy-task-definition@upgrade-to-node-20
         with:
           task-definition: new-task-definition.json
           cluster: ${{ inputs.cluster }}

--- a/.github/workflows/update-task-definition.yml
+++ b/.github/workflows/update-task-definition.yml
@@ -50,7 +50,7 @@ jobs:
           > new-task-definition.json
 
       - name: Deploy task definition
-        uses: fullfatthings/amazon-ecs-deploy-task-definition@upgrade-to-node-20
+        uses: fullfatthings/amazon-ecs-deploy-task-definition@master
         with:
           task-definition: new-task-definition.json
           cluster: ${{ inputs.cluster }}

--- a/.github/workflows/update-web-service.yml
+++ b/.github/workflows/update-web-service.yml
@@ -53,7 +53,7 @@ jobs:
           > new-task-definition.json
 
       - name: Deploy task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: fullfatthings/amazon-ecs-deploy-task-definition@upgrade-to-node-20
         with:
           task-definition: new-task-definition.json
           service: ${{ inputs.service }}

--- a/.github/workflows/update-web-service.yml
+++ b/.github/workflows/update-web-service.yml
@@ -53,7 +53,7 @@ jobs:
           > new-task-definition.json
 
       - name: Deploy task definition
-        uses: fullfatthings/amazon-ecs-deploy-task-definition@upgrade-to-node-20
+        uses: fullfatthings/amazon-ecs-deploy-task-definition@master
         with:
           task-definition: new-task-definition.json
           service: ${{ inputs.service }}


### PR DESCRIPTION
Needs https://github.com/fullfatthings/amazon-ecs-deploy-task-definition/pull/1 to be merged first.